### PR TITLE
Add Papirus-Light for light theme in HyprV/waybar/scripts/baraction

### DIFF
--- a/HyprV/waybar/scripts/baraction
+++ b/HyprV/waybar/scripts/baraction
@@ -37,8 +37,8 @@ fi
 #set the xfce and GTK theme
 if [ $VER == "v4" ]; then
     if [[ $THEMEIS == "dark.css" ]]; then
-      xfconf-query -c xsettings -p /Net/IconThemeName -s "Papirus-Light"
-      gsettings set org.gnome.desktop.interface icon-theme "Papirus-Light"
+      xfconf-query -c xsettings -p /Net/IconThemeName -s "Papirus"
+      gsettings set org.gnome.desktop.interface icon-theme "Papirus"
     else
       xfconf-query -c xsettings -p /Net/IconThemeName -s "Papirus-Dark"
       gsettings set org.gnome.desktop.interface icon-theme "Papirus-Dark"

--- a/HyprV/waybar/scripts/baraction
+++ b/HyprV/waybar/scripts/baraction
@@ -36,8 +36,13 @@ fi
 
 #set the xfce and GTK theme
 if [ $VER == "v4" ]; then
-    xfconf-query -c xsettings -p /Net/IconThemeName -s "Papirus-Dark"
-    gsettings set org.gnome.desktop.interface icon-theme "Papirus-Dark"
+    if [[ $THEMEIS == "dark.css" ]]; then
+      xfconf-query -c xsettings -p /Net/IconThemeName -s "Papirus-Light"
+      gsettings set org.gnome.desktop.interface icon-theme "Papirus-Light"
+    else
+      xfconf-query -c xsettings -p /Net/IconThemeName -s "Papirus-Dark"
+      gsettings set org.gnome.desktop.interface icon-theme "Papirus-Dark"
+    fi
 else 
     xfconf-query -c xsettings -p /Net/IconThemeName -s "Adwaita$SWITCHTO"
     gsettings set org.gnome.desktop.interface icon-theme "Adwaita$SWITCHTO"


### PR DESCRIPTION
Papirus has a light theme for light interfaces. Right now toolbars on v4-light look like this:
![swappy-20230724_005828](https://github.com/SolDoesTech/HyprV4/assets/4622871/39f356c9-7607-410e-a59e-fde93d0c109a)
The result of a little `if..else..fi` in `HyprV/waybar/scripts/baraction`:
![swappy-20230724_010108](https://github.com/SolDoesTech/HyprV4/assets/4622871/b0b49e1f-be1d-4b82-b1f7-cf8f20d9bf62)
