### PR TITLE
refactor(waybar): deprecated wlr/workspaces

### DIFF
--- a/HyprV/waybar/conf/v1-config.jsonc
+++ b/HyprV/waybar/conf/v1-config.jsonc
@@ -9,7 +9,7 @@
     "modules-left": [
         "clock",
         "custom/weather",
-        "wlr/workspaces"
+        "hyprland/workspaces"
     ],
     "modules-center": ["hyprland/window"],
     "modules-right": [
@@ -36,7 +36,7 @@
         "format": "{}"
     },
 
-    "wlr/workspaces": {
+    "hyprland/workspaces": {
         "disable-scroll": true,
         "all-outputs": true,
         "on-click": "activate",

--- a/HyprV/waybar/conf/v2-config.jsonc
+++ b/HyprV/waybar/conf/v2-config.jsonc
@@ -8,7 +8,7 @@
     "height": 50,
     "modules-left": [
         "custom/launch_wofi",
-        "wlr/workspaces",
+        "hyprland/workspaces",
         "cpu",
         "memory",
         "disk",
@@ -94,7 +94,7 @@
         "tooltip": true
     },
 
-    "wlr/workspaces": {
+    "hyprland/workspaces": {
         "disable-scroll": true,
         "all-outputs": true,
         "on-click": "activate",

--- a/HyprV/waybar/conf/v3-config.jsonc
+++ b/HyprV/waybar/conf/v3-config.jsonc
@@ -10,7 +10,7 @@
         "custom/launch_wofi",
         "custom/power_btn",
         "custom/lock_screen",
-        "wlr/workspaces",
+        "hyprland/workspaces",
         "wlr/taskbar"
     ],
     "modules-right": [
@@ -56,7 +56,7 @@
         "tooltip": false
     },
 
-    "wlr/workspaces": {
+    "hyprland/workspaces": {
         "disable-scroll": true,
         "all-outputs": true,
         "on-click": "activate",

--- a/HyprV/waybar/conf/v4-config.jsonc
+++ b/HyprV/waybar/conf/v4-config.jsonc
@@ -9,7 +9,7 @@
     "modules-left": [
         "custom/power_btn",
         "custom/lock_screen",
-        "wlr/workspaces"
+        "hyprland/workspaces"
     ],
     "modules-center": [
         "idle_inhibitor",
@@ -65,7 +65,7 @@
         "tooltip": false
     },
 
-    "wlr/workspaces": {
+    "hyprland/workspaces": {
         "disable-scroll": true,
         "all-outputs": true,
         "on-click": "activate",


### PR DESCRIPTION
Since ext-workspace-unstable-v1 implementation removed from hyprland, wlr/workspace module will no longer work. They find the implementation memory-unsafe. This changes contains basic changes for waybar module that show workspace in waybar.

refs:
 - https://github.com/hyprwm/Hyprland/commit/b48f810a12d5e72e21c0a3c3c8020499a3fc7f86
 - https://github.com/hyprwm/Hyprland/commit/bb0933437f4602080a66cc877fee36dce8dcb3ff