### PR TITLE
Fix Background Initialization Issue

### DIFF
--- a/HyprV/hyprv_util
+++ b/HyprV/hyprv_util
@@ -49,8 +49,9 @@ restart_waybar() {
 set_current_background() {
     get_theme
     get_ver
+    sleep 0.5 # wait for swww to start completely
     
-    if [[ ! -z "$SET_BG" ]]; then
+    if [[ -z "$SET_BG" ]]; then # if background is not set
         #set the current background
         if [[ $THEMEIS == "dark.css" ]]; then
             swww img ~/.config/HyprV/backgrounds/$VER'-background-dark.jpg'


### PR DESCRIPTION
### Issue
Upon first login, the background image wasn't being set and displayed as a dark image. This was due to premature `swww` initialization and incorrect `$SET_BG` handling.
### Changes
- Added sleep `0.5` to ensure `swww` initializes before setting the background.
- Changed the if condition to check for an empty `$SET_BG` and set the default background accordingly.