### PR TITLE
fix: A serious performance issue

### DIFF
--- a/HyprV/hypr/hyprland.conf
+++ b/HyprV/hypr/hyprland.conf
@@ -17,12 +17,12 @@ exec-once = dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CUR
 exec-once = systemctl --user import-environment WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
 exec-once = /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1
 exec-once = swww init
-exec = waybar
+exec-once = waybar
 exec-once = mako
 exec-once = blueman-applet
 exec-once = nm-applet --indicator
 exec-once = wl-paste --watch cliphist store
-exec = ~/.config/HyprV/hyprv_util setbg
+exec-once = ~/.config/HyprV/hyprv_util setbg
 
 # For all categories, see https://wiki.hyprland.org/Configuring/Variables/
 input {


### PR DESCRIPTION
Making both the setbg script of hyprv_util and waybar as `exec` will make them always start another process and thus, that will lead to reduced performance
Changing them to `exec-once` will not make another process start, and fret not, my testing shows that changing set custom backgrounds still work and changing hyprv versions also work.
If there's any issues caused by this that I am not aware of, please let me know so I can make the needed changes before this pull request can be merged!