### PR TITLE
nwg-look-bin has been deprecated and replaced with nwg-look

### DIFF
--- a/set-hypr
+++ b/set-hypr
@@ -71,7 +71,7 @@ install_stage=(
     noto-fonts-emoji 
     lxappearance 
     xfce4-settings
-    nwg-look-bin
+    nwg-look
     sddm
 )
 


### PR DESCRIPTION
The nwg-look-bin has been deprecated and was causing error an error as the package couldn't be found. The nwg-look-bin had been replaced with nwg-look, so I've replaced the nwg-look-bin with nwg-look in the hyprland script.