### PR TITLE
Update set-hypr (nwg-look-bin replaced by nwg-look?)

### DIFF
--- a/set-hypr
+++ b/set-hypr
@@ -71,7 +71,7 @@ install_stage=(
     noto-fonts-emoji 
     lxappearance 
     xfce4-settings
-    nwg-look-bin
+    nwg-look
     sddm
 )
 


### PR DESCRIPTION
Please verify, but it looks like nwg-look-bin no longer in aur